### PR TITLE
Added k8s watchers for deployments to auto-update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   test: &test
     working_directory: /go/src/github.com/utilitywarehouse/health-aggregator
     docker:
-    - image: circleci/golang:1.9
+    - image: circleci/golang:1.10
     - image: mongo:3.6
     steps:
       - checkout
@@ -39,7 +39,7 @@ jobs:
   build-latest:
     working_directory: /go/src/github.com/utilitywarehouse/health-aggregator
     docker:
-    - image: circleci/golang:1.9
+    - image: circleci/golang:1.10
     steps:
       - setup_remote_docker:
           version: 17.06.0-ce

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.8
 
 ARG GITHUB_TOKEN
 ARG SERVICE

--- a/internal/discovery/discovery_test.go
+++ b/internal/discovery/discovery_test.go
@@ -72,7 +72,7 @@ func Test_GetClusterHealthcheckConfig(t *testing.T) {
 	services := make(chan model.Service, 10)
 	errs := make(chan error, 10)
 
-	s := &K8sDiscovery{K8sClient: client, Namespaces: namespaces, Services: services, Errors: errs}
+	s := &KubeDiscoveryService{K8sClient: client, Namespaces: namespaces, Services: services, Errors: errs}
 
 	go func() {
 		s.GetClusterHealthcheckConfig()

--- a/internal/helpers/helpers.go
+++ b/internal/helpers/helpers.go
@@ -55,10 +55,10 @@ func GenerateDummyServiceStatus(serviceName string, namespaceName string, podNam
 	svc.HealthAnnotations.Port = "3000"
 	svc.AppPort = "8080"
 
-	var deployInfo model.DeployInfo
-	deployInfo.DesiredReplicas = int32(len(podNames))
+	var deployment model.Deployment
+	deployment.DesiredReplicas = int32(len(podNames))
 
-	svc.Deployment = deployInfo
+	svc.Deployment = deployment
 
 	healthCheck.Service = svc
 
@@ -141,10 +141,10 @@ func generateDummyService(numReplicas int) model.Service {
 	svc.HealthAnnotations.Port = "3000"
 	svc.AppPort = "8080"
 
-	var deployInfo model.DeployInfo
-	deployInfo.DesiredReplicas = int32(numReplicas)
+	var deployment model.Deployment
+	deployment.DesiredReplicas = int32(numReplicas)
 
-	svc.Deployment = deployInfo
+	svc.Deployment = deployment
 
 	return svc
 }

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -9,7 +9,7 @@ type Service struct {
 	HealthcheckURL    string            `json:"healthcheckURL" bson:"healthcheckURL"`
 	HealthAnnotations HealthAnnotations `json:"healthAnnotations" bson:"healthAnnotations"`
 	AppPort           string            `json:"appPort" bson:"appPort"`
-	Deployment        DeployInfo        `json:"deployment" bson:"deployment"`
+	Deployment        Deployment        `json:"deployment" bson:"deployment"`
 }
 
 // Pod describes a k8s pod
@@ -20,15 +20,23 @@ type Pod struct {
 	ServiceName string
 }
 
-// DeployInfo describes k8s deployment information, limited to DesiredReplicas
-type DeployInfo struct {
-	DesiredReplicas int32 `json:"desiredReplicas" bson:"desiredReplicas"`
+// Deployment describes k8s deployment information, limited to DesiredReplicas
+type Deployment struct {
+	Service         string `json:"-"`
+	Namespace       string `json:"-"`
+	DesiredReplicas int32  `json:"desiredReplicas" bson:"desiredReplicas"`
 }
 
 // Namespace desribes a k8s Namespace including the associated Health Aggregator configuration
 type Namespace struct {
 	Name              string            `json:"name" bson:"name"`
 	HealthAnnotations HealthAnnotations `json:"healthAnnotations" bson:"healthAnnotations"`
+}
+
+// UpdateItem is...
+type UpdateItem struct {
+	Type   string
+	Object interface{}
 }
 
 // HealthAnnotations matching the associated annotations against the resource in k8s
@@ -84,8 +92,15 @@ type Check struct {
 
 // TemplatedChecks wraps a list of HealthcheckResp for rendering in an html template
 type TemplatedChecks struct {
-	Namespace string
-	Zoom      string
-	BigScreen bool
-	Compact   bool
+	Namespace                      string
+	Zoom                           string
+	BigScreen                      bool
+	Compact                        bool
+	HealthAggregatorAPIDevBaseURL  string
+	HealthAggregatorAPIProdBaseURL string
+}
+
+// ServicesStateKey is a struct that acts as a key for the state map: map[model.ServicesStateKey]model.Service
+type ServicesStateKey struct {
+	Namespace, Service string
 }

--- a/internal/templates/nschecks.html
+++ b/internal/templates/nschecks.html
@@ -194,18 +194,23 @@
                     var namespace = '{{.Namespace}}';
                     var env = getParameterByName('env');
                     var ribbon = document.getElementById("env-ribbon");
+                    var healthBaseUrl = '';
                     
                     ribbon.innerHTML = env;
                     if (env == 'prod') {
                         ribbon.classList.add("red");
+                        healthBaseUrl = '{{.HealthAggregatorAPIProdBaseURL}}';
                     } else {
                         ribbon.classList.add("blue");
+                        healthBaseUrl = '{{.HealthAggregatorAPIDevBaseURL}}';
                     }
                     ribbon.classList.add("mystyle");
                     if (env == "" || env == null) {
                         env = 'prod';
                     }
-                    healthUrl = 'https://health-aggregator.'+env+'.uw.systems/namespaces/'+namespace+'/services/checks'
+                    
+                    var healthUrl = healthBaseUrl + '/namespaces/'+namespace+'/services/checks';
+
                     $.ajax({
                               url: healthUrl,
                               type: "GET",
@@ -356,7 +361,7 @@
                                                 '<dd>'+value.previousState+'</dd>' +
                                             '</div>' +
                                         '</div>' +
-                                        '<a href="/namespaces/{{$.Namespace}}/services/'+serviceName+'/checks"class="btn btn-primary">History</a>' +
+                                        '<a href="' + healthBaseUrl + '/namespaces/{{$.Namespace}}/services/'+serviceName+'/checks" class="btn btn-primary">History</a>' +
                                     '</div>' +
                                 '</div> <!-- end of collapse-'+serviceName+' -->');
                                     


### PR DESCRIPTION
Also, some refactoring.
Made URLs in GUI template configurable - change requested by others who wish to run their own health aggregator instance - makes sense to not hard-code URLs in any case.